### PR TITLE
Fix session close bug at #1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,6 @@ module goEVTXWatcher
 
 go 1.21.5
 
-require (
-	github.com/tidwall/gjson v1.17.1
-	golang.org/x/sys v0.17.0
-)
+require golang.org/x/sys v0.17.0
 
-require (
-	github.com/bi-zone/etw v0.0.0-20210519083747-fe9042eb0ea8
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
-)
+require github.com/bi-zone/etw v0.0.0-20210519083747-fe9042eb0ea8

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,6 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
-github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/watcher/etw.go
+++ b/watcher/etw.go
@@ -1,11 +1,12 @@
 package watcher
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"os/signal"
+	"regexp"
 	"sync"
 
 	"github.com/bi-zone/etw"
@@ -14,43 +15,40 @@ import (
 
 func RunETWByGuid(guidInput string) {
 	// Subscribe to the event via the given GUID
-	guid, _ := windows.GUIDFromString(fmt.Sprintf("{%s}", guidInput))
+	guid, err := windows.GUIDFromString(fmt.Sprintf("{%s}", guidInput))
+	if err != nil {
+		log.Panicf("Error parsing GUID: %s", err)
+		return
+	}
+
+	fmt.Printf("Trying to create ETW session for GUID: %s\n", guidInput)
 	etwSession, err := etw.NewSession(guid)
-	log.Printf("Session is being created (via GUID %v)\n", guid)
 	if err != nil {
 		log.Panicf("Error creating ETW session: %s", err)
 		return
 	}
+	etwSessionName, err := extractEtwSessionName(etwSession)
+	if err != nil {
+		log.Panicf("Error extracting ETW session name: %s", err)
+	}
+	log.Printf("ETW session created and registered: %s\n", etwSessionName)
 
 	// A callback function for ETW
-	etwSessionCallBack := func(etwEvent *etw.Event) {
-		// Print the event
-		eventProperties, err := etwEvent.EventProperties()
-		if err != nil {
-			log.Printf("Error getting event properties: %s", err)
-		}
-
-		jsonifiedEventProperties, err := json.Marshal(eventProperties)
-		if err != nil {
-			log.Printf("Error marshalling event properties: %s", err)
-			return
-		}
-
-		log.Printf("Event: %s", string(jsonifiedEventProperties))
-	}
-
+	etwSessionCallBack := etwSessionCallback
 	var etwWaitGroup sync.WaitGroup
 	etwWaitGroup.Add(1)
 
 	// Goroutine to handle termination signal
 	go func() {
+		// handling signal
 		trapCancelSignal := make(chan os.Signal, 1)
 		signal.Notify(trapCancelSignal, os.Interrupt)
-		<-trapCancelSignal // Wait for the termination signal
+		<-trapCancelSignal // Block until a signal is received
+
+		// Terminate the ETW session
 		log.Println("Received termination signal. Closing ETW session.")
-		// if err := etwSession.Close(); err != nil {
-		// 	log.Printf("Error closing ETW session: %s", err)
-		// }
+		log.Printf("Terminate ETW session: %s\n", etwSessionName)
+		terminateEtwSession(etwSessionName)
 		etwWaitGroup.Done()
 	}()
 
@@ -62,4 +60,41 @@ func RunETWByGuid(guidInput string) {
 	}()
 
 	etwWaitGroup.Wait()
+}
+
+// Directly extract the ETW session name from the etw.Session object
+// It looks like the official method is absent, so we have to use a workaround
+func extractEtwSessionName(etwSession *etw.Session) (string, error) {
+	etwSessionString := fmt.Sprintf("%v", etwSession)
+	// According to the package implementation, the etw.Session object is printed as "go-etw-{random_guid}"
+	etwSessionNameMatchPattern := `go-etw-\{[^\}]+\}`
+
+	re, err := regexp.Compile(etwSessionNameMatchPattern)
+	if err != nil {
+		return "", err
+	}
+
+	match := re.FindString(etwSessionString)
+	if match == "" {
+		return "", fmt.Errorf("no match found for pattern: %s", etwSessionNameMatchPattern)
+	}
+
+	return match, nil
+}
+
+// A callback function for ETW
+func etwSessionCallback(etwEvent *etw.Event) {
+	log.Printf("=> Event #%v just has been captured\n", etwEvent.Header.ID)
+}
+
+// Terminate the ETW session by the given etw session name
+func terminateEtwSession(etwSessionName string) error {
+	logmanCommand := fmt.Sprintf("logman stop \"%s\" -ets", etwSessionName)
+	terminateCommand := exec.Command("powershell", "-Command", logmanCommand)
+	err := terminateCommand.Run()
+	if err != nil {
+		return fmt.Errorf("error terminating ETW session: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Refer to Issue #1

We decided to utilize the logman command to ensure confidence in operation instead.
The previous bug fix by just deleting the `Close()` method was inappropriate.